### PR TITLE
DOCTYPE 宣言前の改行コードの削除

### DIFF
--- a/header.php
+++ b/header.php
@@ -3,8 +3,7 @@
    * @package WordPress
    * @subpackage modest3
    */
-   ?>
-<!DOCTYPE html>
+?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
   <meta charset="<?php bloginfo( 'charset' ); ?>" />


### PR DESCRIPTION
もうあまり気にする必要は無いかもしれませんが、DOCTYPE 宣言前の改行コードを削除し、IE6の互換モードへの切り替わりを防ぐものです。
