### PR TITLE
::selection の変更

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,9 +126,13 @@ a:hover,a:active{
 /* ::selection pseudo-element */
 ::-moz-selection {
   background: #6bd7f3;
+  color: #000;
+  text-shadow: none;
 }
 ::selection {
   background: #6bd7f3;
+  color: #000;
+  text-shadow: none;
 }
 img::-moz-selection {
   background: transparent;


### PR DESCRIPTION
::selection に背景色のみが指定されている場合、文字色とテキストシャドウの状態によって選択時に文字が読みにくい部分が発生する可能性があります。文字色の固定及びテキストシャドウの無効化により、このような問題を修正しています。
