### PR TITLE
ブラウザズーム対応

### DIFF
--- a/style.css
+++ b/style.css
@@ -571,6 +571,7 @@ body {
 */
 #tabzilla {
   background-image: url("./images/tabzilla-tab.png") !important;
+  background-repeat: no-repeat;
 }
 /*
 #tabzilla:after {


### PR DESCRIPTION
ブラウザのページズーム機能を使用した際に、領域サイズ誤差の発生により一部のブラウザでリピートされた背景が 1px 現れ、白い水平線の様に表示される問題を修正しています。
