### PR TITLE
meta[name=title] の削除

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,7 +11,6 @@
 
   <title><?php wp_title('|', true, 'right'); ?><?php bloginfo('name'); ?></title>
 
-  <meta name="title" content="<?php if (is_singular()) : single_post_title(); echo ' | '; endif; bloginfo('name'); ?>" />
   <meta name="description" content="<?php fc_meta_desc(); ?>" />
 
   <meta property="og:site_name" content="<?php bloginfo('name'); ?>" />


### PR DESCRIPTION
標準に存在しない meta[name=title] を削除しています。
何か特別な理由が無い限り、これは必要ないと思われます。
