### PR TITLE
label 要素の for 属性を修正

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -10,7 +10,7 @@
       role="search"
       method="get"
       action="<?php echo home_url( '/' ); ?>">
-  <label for="search_field">検索 :</label>
+  <label for="s">検索 :</label>
   <input id="s"
          class=""
          type="text"


### PR DESCRIPTION
ラベルは css で非表示にされている様ですが、仮に表示されていた場合、ラベルをクリックした時にその for 属性の指し示すフォームコントロールにフォーカスが移動します。
非表示により視覚ブラウザで問題が発生していないとしても、他の環境でなんらかのアクセシビリティに関する問題が発生しているかもしれません（未確認）。

よってこれを修正しています。
